### PR TITLE
Обработчик ошибок заменил на этот https://www.npmjs.com/package/gulp-notify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,8 @@ var gulp           = require('gulp'),
 		fileinclude    = require('gulp-file-include'),
 		gulpRemoveHtml = require('gulp-remove-html'),
 		bourbon        = require('node-bourbon'),
-		ftp            = require('vinyl-ftp');
+		ftp            = require('vinyl-ftp'),
+		notify         = require("gulp-notify");
 
 gulp.task('browser-sync', function() {
 	browserSync({
@@ -29,7 +30,7 @@ gulp.task('sass', ['headersass'], function() {
 	return gulp.src('app/sass/**/*.sass')
 		.pipe(sass({
 			includePaths: bourbon.includePaths
-		}).on('error', sass.logError))
+		}).on("error", notify.onError()))
 		.pipe(rename({suffix: '.min', prefix : ''}))
 		.pipe(autoprefixer(['last 15 versions']))
 		.pipe(cleanCSS())
@@ -41,7 +42,7 @@ gulp.task('headersass', function() {
 	return gulp.src('app/header.sass')
 		.pipe(sass({
 			includePaths: bourbon.includePaths
-		}).on('error', sass.logError))
+		}).on("error", notify.onError()))
 		.pipe(rename({suffix: '.min', prefix : ''}))
 		.pipe(autoprefixer(['last 15 versions']))
 		.pipe(cleanCSS())

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-file-include": "^0.14.0",
     "gulp-imagemin": "^3.0.3",
+    "gulp-notify": "^2.2.0",
     "gulp-remove-html": "^1.1.2",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.2.0",


### PR DESCRIPTION
При сохранении в редакторе кода позволяет мгновенно увидеть сообщение об ошибке во всплывающем окне панели уведомлений операционной системы.
