### PR TITLE
AddType x-font-woff2

### DIFF
--- a/app/ht.access
+++ b/app/ht.access
@@ -5,6 +5,7 @@ AddType application/vnd.ms-fontobject .eot
 AddType application/x-font-ttf .ttf
 AddType application/x-font-opentype .otf
 AddType application/x-font-woff .woff
+AddType application/x-font-woff2 .woff2
 AddType image/svg+xml .svg
 
 # Compress compressible fonts
@@ -25,6 +26,7 @@ ExpiresByType application/vnd.ms-fontobject "access plus 2592000 seconds"
 ExpiresByType application/x-font-ttf "access plus 2592000 seconds"
 ExpiresByType application/x-font-opentype "access plus 2592000 seconds"
 ExpiresByType application/x-font-woff "access plus 2592000 seconds"
+ExpiresByType application/x-font-woff2 "access plus 2592000 seconds"
 ExpiresByType image/svg+xml "access plus 2592000 seconds"
 
 # Cache other content types (Flash, CSS, JS, HTML, XML)


### PR DESCRIPTION
В уроке Джедай верстки #7 на Google PageSpeed нужно было оптимизировать woff2. Мое мнение - т.к. он находится в font-awesome. Спасибо за уроки - хорошие знания.